### PR TITLE
Using binding wildcards

### DIFF
--- a/lib/mumukit/inspection/expectation.rb
+++ b/lib/mumukit/inspection/expectation.rb
@@ -69,7 +69,7 @@ class Mumukit::Inspection::Expectation
     end
 
     def as_v2_declare(simple_type)
-      V2.new '', new_inspection("Declares#{simple_type}", Mumukit::Inspection::Target.named(binding))
+      V2.new '*', new_inspection("Declares#{simple_type}", Mumukit::Inspection::Target.named(binding))
     end
 
     def new_inspection(type, target)

--- a/lib/mumukit/inspection/i18n.rb
+++ b/lib/mumukit/inspection/i18n.rb
@@ -20,7 +20,7 @@ module Mumukit::Inspection::I18n
     end
 
     def t_binding(binding)
-      binding.present? ? "<strong>#{Mumukit::Inspection.parse_binding_name binding}</strong>" : ::I18n.t("expectation_solution")
+      binding == '*' ? ::I18n.t("expectation_solution") : "<strong>#{Mumukit::Inspection.parse_binding_name binding}</strong>"
     end
 
     def t_must(parsed)

--- a/spec/format_spec.rb
+++ b/spec/format_spec.rb
@@ -30,37 +30,37 @@ describe Mumukit::Inspection::Expectation do
   end
 
   describe 'it can adapt to latest format' do
-    it { expect(subject.parse(binding: '', inspection: 'Declares:foo').as_v2)
-          .to json_like binding: '', inspection: {type: 'Declares', target: {type: :unknown, value: 'foo'}, negated: false   }  }
+    it { expect(subject.parse(binding: '*', inspection: 'Declares:foo').as_v2)
+          .to json_like binding: '*', inspection: {type: 'Declares', target: {type: :unknown, value: 'foo'}, negated: false   }  }
     it { expect(subject.parse(binding: 'foo', inspection: 'HasBinding').as_v2)
-          .to json_like binding: '', inspection: {type: 'Declares', target: {type: :named, value: 'foo'}, negated: false}   }
+          .to json_like binding: '*', inspection: {type: 'Declares', target: {type: :named, value: 'foo'}, negated: false}   }
     it { expect(subject.parse(binding: 'foo', inspection: 'Not:HasBinding').as_v2)
-          .to json_like binding: '', inspection: {type: 'Declares', target: {type: :named, value: 'foo'}, negated: true}   }
+          .to json_like binding: '*', inspection: {type: 'Declares', target: {type: :named, value: 'foo'}, negated: true}   }
 
     it { expect(subject.parse(binding: 'foo', inspection: 'HasTypeDeclaration').as_v2)
-          .to json_like binding: '', inspection: {type: 'DeclaresTypeAlias', target: {type: :named, value: 'foo'}, negated: false}   }
+          .to json_like binding: '*', inspection: {type: 'DeclaresTypeAlias', target: {type: :named, value: 'foo'}, negated: false}   }
     it { expect(subject.parse(binding: 'foo', inspection: 'Not:HasTypeDeclaration').as_v2)
-          .to json_like binding: '', inspection: {type: 'DeclaresTypeAlias', target: {type: :named, value: 'foo'}, negated: true}   }
+          .to json_like binding: '*', inspection: {type: 'DeclaresTypeAlias', target: {type: :named, value: 'foo'}, negated: true}   }
 
     it { expect(subject.parse(binding: 'foo', inspection: 'HasTypeSignature').as_v2)
-          .to json_like binding: '', inspection: {type: 'DeclaresTypeSignature', target: {type: :named, value: 'foo'}, negated: false}   }
+          .to json_like binding: '*', inspection: {type: 'DeclaresTypeSignature', target: {type: :named, value: 'foo'}, negated: false}   }
     it { expect(subject.parse(binding: 'foo', inspection: 'Not:HasTypeSignature').as_v2)
-          .to json_like binding: '', inspection: {type: 'DeclaresTypeSignature', target: {type: :named, value: 'foo'}, negated: true}   }
+          .to json_like binding: '*', inspection: {type: 'DeclaresTypeSignature', target: {type: :named, value: 'foo'}, negated: true}   }
 
     it { expect(subject.parse(binding: 'foo', inspection: 'HasVariable').as_v2)
-          .to json_like binding: '', inspection: {type: 'DeclaresVariable', target: {type: :named, value: 'foo'}, negated: false}   }
+          .to json_like binding: '*', inspection: {type: 'DeclaresVariable', target: {type: :named, value: 'foo'}, negated: false}   }
     it { expect(subject.parse(binding: 'foo', inspection: 'Not:HasVariable').as_v2)
-          .to json_like binding: '', inspection: {type: 'DeclaresVariable', target: {type: :named, value: 'foo'}, negated: true}   }
+          .to json_like binding: '*', inspection: {type: 'DeclaresVariable', target: {type: :named, value: 'foo'}, negated: true}   }
 
     it { expect(subject.parse(binding: 'foo', inspection: 'HasArity:1').as_v2)
-          .to json_like binding: '', inspection: {type: 'DeclaresComputationWithArity1', target: {type: :named, value: 'foo'}, negated: false}   }
+          .to json_like binding: '*', inspection: {type: 'DeclaresComputationWithArity1', target: {type: :named, value: 'foo'}, negated: false}   }
     it { expect(subject.parse(binding: 'foo', inspection: 'Not:HasArity:3').as_v2)
-          .to json_like binding: '', inspection: {type: 'DeclaresComputationWithArity3', target: {type: :named, value: 'foo'}, negated: true}   }
+          .to json_like binding: '*', inspection: {type: 'DeclaresComputationWithArity3', target: {type: :named, value: 'foo'}, negated: true}   }
 
     it { expect(subject.parse(binding: 'foo', inspection: 'HasDirectRecursion').as_v2)
-          .to json_like binding: '', inspection: {type: 'DeclaresRecursively', target: {type: :named, value: 'foo'}, negated: false}   }
+          .to json_like binding: '*', inspection: {type: 'DeclaresRecursively', target: {type: :named, value: 'foo'}, negated: false}   }
     it { expect(subject.parse(binding: 'foo', inspection: 'Not:HasDirectRecursion').as_v2)
-          .to json_like binding: '', inspection: {type: 'DeclaresRecursively', target: {type: :named, value: 'foo'}, negated: true}   }
+          .to json_like binding: '*', inspection: {type: 'DeclaresRecursively', target: {type: :named, value: 'foo'}, negated: true}   }
 
     it { expect(subject.parse(binding: 'foo', inspection: 'HasComposition').as_v2)
           .to json_like binding: 'foo', inspection: {type: 'UsesComposition', target: nil, negated: false}   }

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -9,7 +9,7 @@ describe Mumukit::Inspection::I18n do
   context 'en locale' do
     before { I18n.locale = :en }
 
-    it { expect(translate_expectation('', 'Declares:foo')).to eq('solution must declare <strong>foo</strong>') }
+    it { expect(translate_expectation('*', 'Declares:foo')).to eq('solution must declare <strong>foo</strong>') }
     it { expect(translate_expectation('foo', 'Not:Uses:baz')).to eq('<strong>foo</strong> must not use <strong>baz</strong>') }
     it { expect(translate_expectation('foo', 'Not:UsesLambda')).to eq('<strong>foo</strong> must not use lambda expressions') }
   end
@@ -23,12 +23,12 @@ describe Mumukit::Inspection::I18n do
     end
 
     describe 'v2 expectations' do
-      it { expect(translate_expectation('', 'Declares:foo')).to eq('la solución debe declarar <strong>foo</strong>') }
-      it { expect(translate_expectation('', 'DeclaresClass:foo')).to eq('la solución debe declarar una clase <strong>foo</strong>') }
+      it { expect(translate_expectation('*', 'Declares:foo')).to eq('la solución debe declarar <strong>foo</strong>') }
+      it { expect(translate_expectation('*', 'DeclaresClass:foo')).to eq('la solución debe declarar una clase <strong>foo</strong>') }
 
       it { expect(translate_expectation('Mumukit', 'DeclaresClass:Inspection')).to eq('<strong>Mumukit</strong> debe declarar una clase <strong>Inspection</strong>') }
 
-      it { expect(translate_expectation('', 'DeclaresObject:foo')).to eq('la solución debe declarar un objeto <strong>foo</strong>') }
+      it { expect(translate_expectation('*', 'DeclaresObject:foo')).to eq('la solución debe declarar un objeto <strong>foo</strong>') }
       it { expect(translate_expectation('foo', 'DeclaresMethod:bar')).to eq('<strong>foo</strong> debe declarar un método <strong>bar</strong>') }
       it { expect(translate_expectation('foo', 'Declares')).to eq('<strong>foo</strong> debe contener declaraciones') }
 
@@ -53,12 +53,12 @@ describe Mumukit::Inspection::I18n do
       it { expect(translate_expectation('foo', 'Not:Uses:baz')).to eq('<strong>foo</strong> no debe utilizar <strong>baz</strong>') }
       it { expect(translate_expectation('foo', 'Not:UsesLambda')).to eq('<strong>foo</strong> no debe emplear expresiones lambda') }
 
-      it { expect(translate_expectation('', 'DeclaresClass')).to eq('la solución debe declarar clases') }
-      it { expect(translate_expectation('', 'Not:DeclaresMethod')).to eq('la solución no debe declarar métodos') }
-      it { expect(translate_expectation('', 'Not:DeclaresClass')).to eq('la solución no debe declarar clases') }
+      it { expect(translate_expectation('*', 'DeclaresClass')).to eq('la solución debe declarar clases') }
+      it { expect(translate_expectation('*', 'Not:DeclaresMethod')).to eq('la solución no debe declarar métodos') }
+      it { expect(translate_expectation('*', 'Not:DeclaresClass')).to eq('la solución no debe declarar clases') }
 
       it { expect(translate_expectation('foo', 'DeclaresObject')).to eq('<strong>foo</strong> debe declarar objetos') }
-      it { expect(translate_expectation('', 'Not:DeclaresClass')).to eq('la solución no debe declarar clases') }
+      it { expect(translate_expectation('*', 'Not:DeclaresClass')).to eq('la solución no debe declarar clases') }
     end
   end
 end


### PR DESCRIPTION
This PRs adds support for declaring wildcards in expectation's bindings, compatible with `mumuki-laboratory` and `mumuki-bibliotheca` 